### PR TITLE
fix: accept name column regardless of capitilzation

### DIFF
--- a/lts_island_connectivity/connections.py
+++ b/lts_island_connectivity/connections.py
@@ -134,9 +134,12 @@ class StudySegment:
         )
         self.summarize_stats()
 
+    def __get_name(self):
+        return self.properties.get("name") or self.properties.get("Name")
+
     def __sanitize_name(self):
         """Remove non-standard characters from the segment name"""
-        segment_name = self.properties["name"]
+        segment_name = self.__get_name()
         return re.sub(r"[^a-zA-Z0-9 ]", "", segment_name)
 
     def __update_highest_comfort_level(self):


### PR DESCRIPTION
name or Name columns are both fine (result of delco consultant having issues with esri export of geojson)