### PR TITLE
fix: add schema

### DIFF
--- a/lts_island_connectivity/network_islands.py
+++ b/lts_island_connectivity/network_islands.py
@@ -27,7 +27,7 @@ gapslist = [1, 2, 3]
 for value in gapslist:
     stressbelow = value + 1
     db.execute(
-        f"""drop table if exists lts{value}gaps CASCADE;
+        f"""drop table if exists lts.lts{value}gaps CASCADE;
             create table lts.lts{value}gaps as select * from lts.lts_full lf where lf.lts_score::int > {value};
             alter table lts.lts_stress_below_{stressbelow} add column if not exists source integer;
             alter table lts.lts_stress_below_{stressbelow} add column if not exists target integer;


### PR DESCRIPTION
also had to convert dvrpcid from numeric to int in low stress tables bc pgr was silently failing

note for future- when updating lts, lts_stress_below_x tables need to have the dvrpc_id column recast to int from numeric. otherwise the pgr_create_topology scripts will silently fail and any of the isochrone scripts 